### PR TITLE
added notebook to show how to use pyhydrophone to compute HMD

### DIFF
--- a/notebooks/using_pyhydrophone.ipynb
+++ b/notebooks/using_pyhydrophone.ipynb
@@ -84,8 +84,8 @@
     "subset_to            = (10, 2_000)  # min, max frequencies to subset to \n",
     "\n",
     "# Information of the metadata which will be included in the netcdf files\n",
-    "global_attrs_uri    = 'NRS11/globalAttributes_NRS11.yaml'\n",
-    "variable_attrs_uri  = 'NRS11/variableAttributes_NRS11.yaml'"
+    "global_attrs_uri    = 'metadata/mb05/globalAttributes_NRS11.yaml'\n",
+    "variable_attrs_uri  = 'metadata/mb05/variableAttributes_NRS11.yaml'"
    ],
    "id": "cea6ee503b469771"
   },


### PR DESCRIPTION
Added a notebook to showcase the use of pyhydrophone together with pbp to automatically obtain calibration information from soundtrap.

Fixes #73, related to #45 and #43

I did not test the notebook yet